### PR TITLE
fix: update setting name.

### DIFF
--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -45,7 +45,11 @@ RUN sed -i 's/^MaxScanSize .*$/MaxScanSize 4000M/g' /etc/clamav/clamd.conf && \
     sed -i 's/^StreamMaxLength .*$/StreamMaxLength 4000M/g' /etc/clamav/clamd.conf
 
 # Block encrypted files
-RUN sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
+# NB: The automatically generated (by clamav-daemon postinst) clamd.conf
+#     that we update here contains the *old* setting name, so we attempt to
+#     update both versions of the setting.
+RUN sed -i 's/^ArchiveBlockEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf && \
+    sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
 
 # env based configs - will be called by bootstrap.sh
 COPY envconfig.sh /

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i 's/^MaxScanSize .*$/MaxScanSize 4000M/g' /etc/clamav/clamd.conf && \
     sed -i 's/^StreamMaxLength .*$/StreamMaxLength 4000M/g' /etc/clamav/clamd.conf
 
 # Block encrypted files
-RUN sed -i 's/^ArchiveBlockEncrypted .*$/ArchiveBlockEncrypted true/g' /etc/clamav/clamd.conf
+RUN sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
 
 # env based configs - will be called by bootstrap.sh
 COPY envconfig.sh /

--- a/debian/buster/bootstrap.sh
+++ b/debian/buster/bootstrap.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 # bootstrap clam av service and clam av database updater shell script
 # presented by mko (Markus Kosmal<dude@m-ko.de>)
-set -m
+set -m  # job control
 
 # Configure freshclam.conf and clamd.conf from env variables if present
 source /envconfig.sh
 
+# Check if this is a first time run
+# The virus definition database is stored in ``/var/lib/clamav``.
+# Use ``-v clamdb:/var/lib/clamav`` option with docker run command
+# to persist and avoid download of db every time we start the daemon.
+if [ -z "$(ls -A /var/lib/clamav)" ]; then
+    # Run freshclam in foreground to avoid container exiting
+    # while we get fresh defs.
+    echo "No ClamAV database - running freshclam for first time"
+    freshclam
+else
+    echo "ClamAV database found!"
+fi
+
 # Start clamd service in background
+echo "Starting clamd in background"
 clamd &
 
 # Based on https://superuser.com/a/917073/66341
@@ -15,7 +29,7 @@ wait_file() {
   local file="$1"; shift
   local wait_seconds="${1:-10}"; shift # 10 seconds as default timeout
 
-  echo "Waiting $wait_seconds for $file"
+  echo "Waiting $wait_seconds seconds for $file"
 
   until test $((wait_seconds--)) -eq 0 -o -S "$file" ; 
   do
@@ -30,8 +44,8 @@ wait_file "$LOCKFILE" 60 || {
     >&2 echo "$LOCKFILE not found after waiting for 60 seconds. There may be issues with updating virus defs"
 }
 
-# Start the updater in background as daemon
-echo "Starting freshclam"
+# Clamd should be up, start the updater in background as daemon
+echo "Starting freshclam in background"
 freshclam -d &
 
 # recognize PIDs

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -41,7 +41,7 @@ RUN sed -i 's/^MaxScanSize .*$/MaxScanSize 4000M/g' /etc/clamav/clamd.conf && \
     sed -i 's/^StreamMaxLength .*$/StreamMaxLength 4000M/g' /etc/clamav/clamd.conf
 
 # Block encrypted files
-RUN sed -i 's/^ArchiveBlockEncrypted .*$/ArchiveBlockEncrypted true/g' /etc/clamav/clamd.conf
+RUN sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
 
 # volume provision
 VOLUME ["/var/lib/clamav"]

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
         clamav-daemon \
         clamav-freshclam \
         libclamunrar9 \
+        ca-certificates \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -41,10 +42,11 @@ RUN sed -i 's/^MaxScanSize .*$/MaxScanSize 4000M/g' /etc/clamav/clamd.conf && \
     sed -i 's/^StreamMaxLength .*$/StreamMaxLength 4000M/g' /etc/clamav/clamd.conf
 
 # Block encrypted files
-RUN sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
-
-# volume provision
-VOLUME ["/var/lib/clamav"]
+# NB: The automatically generated (by clamav-daemon postinst) clamd.conf
+#     that we update here contains the *old* setting name, so we attempt to
+#     update both versions of the setting.
+RUN sed -i 's/^ArchiveBlockEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf && \
+    sed -i 's/^AlertEncrypted .*$/AlertEncrypted true/g' /etc/clamav/clamd.conf
 
 # port provision
 EXPOSE 3310

--- a/debian/stretch/bootstrap.sh
+++ b/debian/stretch/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # bootstrap clam av service and clam av database updater shell script
 # presented by mko (Markus Kosmal<dude@m-ko.de>)
-set -e
+set -m  # job control
 
 if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
     echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
@@ -15,7 +15,21 @@ if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
+# Check if this is a first time run
+# The virus definition database is stored in ``/var/lib/clamav``.
+# Use ``-v clamdb:/var/lib/clamav`` option with docker run command
+# to persist and avoid download of db every time we start the daemon.
+if [ -z "$(ls -A /var/lib/clamav)" ]; then
+    # Run freshclam in foreground to avoid container exiting
+    # while we get fresh defs.
+    echo "No ClamAV database - running freshclam for first time"
+    freshclam
+else
+    echo "ClamAV database found!"
+fi
+
 # Start clamd service in background
+echo "Starting clamd in background"
 clamd &
 
 # Based on https://superuser.com/a/917073/66341
@@ -24,7 +38,7 @@ wait_file() {
   local file="$1"; shift
   local wait_seconds="${1:-10}"; shift # 10 seconds as default timeout
 
-  echo "Waiting $wait_seconds for $file"
+  echo "Waiting $wait_seconds seconds for $file"
 
   until test $((wait_seconds--)) -eq 0 -o -S "$file" ; 
   do
@@ -39,8 +53,8 @@ wait_file "$LOCKFILE" 60 || {
     >&2 echo "$LOCKFILE not found after waiting for 60 seconds. There may be issues with updating virus defs"
 }
 
-# Start the updater in background as daemon
-echo "Starting freshclam"
+# Clamd should be up, start the updater in background as daemon
+echo "Starting freshclam in background"
 freshclam -d &
 
 # recognize PIDs


### PR DESCRIPTION
OTB the dockerfiles and bootstraps for `debian/buster` and `debian/stretch` didn’t work. The `ca-certificates` install was missing in `debian/stretch`. Startup in both fails because `/var/lib/clamav` is empty and `clamd` (therefore the container) exits before the database can be downloaded.

`mko-x docker-clamav` get around the cold start situ (probably) by building the image with uncommented wget’s for “# initial update of av databases”. This seems like a pain. The modified bootstrap changes do this on the fly and avoid over-fetching as long as you run the container with a volume (which the authors recommend). 

Additionally - the `ArchiveBlockEncrypted` settings is deprecated, updated to use AlertEncrypted. However - the automatically generated (by clamav-daemon postinst) clamd.conf that we update contains the *old* setting name, so we attempt to update both versions of the setting. See [release notes here](https://blog.clamav.net/2018/12/clamav-01010-has-been-released.html).

Updated README to elaborate on the DIT customisations in our fork.
