### PR TITLE
Update to cisco clamAV image & block encrypted files

### DIFF
--- a/alpine/main-idb/Dockerfile
+++ b/alpine/main-idb/Dockerfile
@@ -1,4 +1,5 @@
-FROM mkodockx/docker-clamav:alpine
+# Pinning to 1.2 instead of stable
+FROM clamav/clamav:1.2
 LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 
 # switch for installation
@@ -13,8 +14,12 @@ COPY ./safebrowsing.cvd  /var/lib/clamav/safebrowsing.cvd
 # permission juggling
 RUN chown clamav:clamav /var/lib/clamav/*.cvd
 
-EXPOSE 3310/tcp
+# Block encrypted files
+# NB: The automatically generated (by clamav-daemon postinst) clamd.conf
+#     that we update here contains the *old* setting name, so we attempt to
+#     update both versions of the setting.
+RUN echo 'AlertEncrypted true' >> /etc/clamav/clamd.conf
 
-USER clamav
+EXPOSE 3310/tcp
 
 CMD ["/bootstrap.sh"]

--- a/alpine/main-idb/Dockerfile
+++ b/alpine/main-idb/Dockerfile
@@ -14,11 +14,15 @@ COPY ./safebrowsing.cvd  /var/lib/clamav/safebrowsing.cvd
 # permission juggling
 RUN chown clamav:clamav /var/lib/clamav/*.cvd
 
+# Change directory permissions to grant clamav user access
+RUN mkdir /var/run/clamav /run/lock && \
+    chown clamav:clamav /var/run/clamav /run/clamav /var/log/clamav /var/lock /run/lock && \
+    chmod 770 /var/run/clamav /run/clamav /var/log/clamav /var/lock /run/lock
+
 # Block encrypted files
-# NB: The automatically generated (by clamav-daemon postinst) clamd.conf
-#     that we update here contains the *old* setting name, so we attempt to
-#     update both versions of the setting.
 RUN echo 'AlertEncrypted true' >> /etc/clamav/clamd.conf
+
+USER clamav
 
 EXPOSE 3310/tcp
 


### PR DESCRIPTION
. Updated image to point to https://github.com/Cisco-Talos/clamav as mko-x/docker-clamav has been deprecated and is no longer supported
. Blocked encrypted files scanning in Alpine image
. Updated permissions to allow clamav user to run scans